### PR TITLE
Configure for remote build: update azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -15,6 +15,7 @@ services:
     project: ./packages/api
     language: ts
     host: function
+    remoteBuild: true
 
 hooks:
   prepackage:


### PR DESCRIPTION
## Summary

Adds `remoteBuild: true` to the Azure Functions service configuration in `azure.yaml`.

## Changes

- **azure.yaml**: Added `remoteBuild: true` under the `api` service

## Context

When deploying Node.js/TypeScript Azure Functions apps with `azd`, remote build is used. Adding `remoteBuild: true` explicitly opts into this behavior and ensures the deployment pipeline is correctly configured.

The `.funcignore` in this repo is already correctly configured for remote build (ignores `node_modules/`, does not ignore `*.ts` or `tsconfig.json`).

## About `remoteBuild: true` in `azure.yaml`

The `remoteBuild: true` flag in `azure.yaml` is being added ahead of support in `azd`. See https://github.com/Azure/azure-dev/pull/6748.

Adding this flag now has no effect on current versions of `azd`, but will be used by new versions that support it. The goal is to explicitly pin the remote build behavior for this project so that it is not affected by potential future changes to the default build behavior in `azd`.